### PR TITLE
Add basic page navigation

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,7 +5,7 @@ import { MainPage } from "./components/MainPage/MainPage";
 import { AboutUsPage } from "./components/AboutUsPage/AboutUsPage";
 
 export function App() {
-  const [currentPage, setCurrentPage] = useState('main');
+  const [currentPage, setCurrentPage] = useState<'main' | 'aboutUs' | 'wishlists' | 'account'>('main');
 
   let page: JSX.Element;
   switch (currentPage) {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,12 +1,39 @@
+import { useState, type JSX } from "react";
 import { Footer } from "./components/Footer/Footer";
 import { Header } from "./components/Header/Header";
 import { MainPage } from "./components/MainPage/MainPage";
+import { AboutUsPage } from "./components/AboutUsPage/AboutUsPage";
 
 export function App() {
+  const [currentPage, setCurrentPage] = useState('main');
+
+  let page: JSX.Element;
+  switch (currentPage) {
+    case 'main':
+      page = <MainPage />
+      break;
+
+    case 'aboutUs':
+      page = <AboutUsPage />
+      break;
+
+    case 'wishlists':
+      page = <MainPage />
+      break;
+
+    case 'account':
+      page = <MainPage />
+      break;
+
+    default:
+      page = <MainPage />
+      break;
+  }
+
   return (
     <>
-      <Header />
-      <MainPage />
+      <Header setPage={setCurrentPage} />
+      {page || <MainPage />}
       <Footer />
     </>
   )

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -3,7 +3,7 @@ import type { Dispatch, SetStateAction } from 'react'
 import styles from './Header.module.scss'
 
 type Props = {
-  setPage: Dispatch<SetStateAction<string>>,
+  setPage: Dispatch<SetStateAction<'main' | 'aboutUs' | 'wishlists' | 'account'>>,
 }
 
 export function Header({ setPage }: Props) {

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -1,18 +1,24 @@
+import type { Dispatch, SetStateAction } from 'react'
+
 import styles from './Header.module.scss'
 
-export function Header() {
+type Props = {
+  setPage: Dispatch<SetStateAction<string>>,
+}
+
+export function Header({ setPage }: Props) {
   return (
     <header>
-        <h1 className={styles.title}>Wish</h1>
+      <h1 className={styles.title}>Wish</h1>
 
-        <nav>
-            <ul>
-                <li><a href="#" className={styles.link}>Главная</a></li>
-                <li><a href="#" className={styles.link}>О нас</a></li>
-                <li><a href="#" className={styles.link}>Вишлисты</a></li>
-                <li><a href="#" className={styles.link}>Мой аккаунт</a></li>
-            </ul>
-        </nav>
+      <nav>
+        <ul>
+          <li><a href="#" className={styles.link} onClick={() => setPage('main')}>Главная</a></li>
+          <li><a href="#" className={styles.link} onClick={() => setPage('aboutUs')}>О нас</a></li>
+          <li><a href="#" className={styles.link} onClick={() => setPage('wishlists')}>Вишлисты</a></li>
+          <li><a href="#" className={styles.link} onClick={() => setPage('account')}>Мой аккаунт</a></li>
+        </ul>
+      </nav>
     </header>
   )
 }


### PR DESCRIPTION
## Что сделано

- Добавлена временная логика переключения страниц через состояние (useState)
- Подключены существующие страницы:
  - Главная
  - О нас
  - [Другие страницы...]
- Реализован базовый навигационный компонент

## Технические детали

``` tsx
const [currentPage, setCurrentPage] = useState<'main' | 'aboutUs' | 'wishlists' | 'account'>('main');
```

⚠️ Временное решение!
## Планы по миграции

1. Установить `react-router-dom`
2. Заменить `useState` на `<BrowserRouter>`
3. Реализовать обработку глубоких ссылок



![Screenshot 2025-06-05 092732](https://github.com/user-attachments/assets/5c797fe1-6a47-47f4-a7d2-86ecc00b7f0e)
![Screenshot 2025-06-05 092744](https://github.com/user-attachments/assets/23bb2fe2-23b8-485a-b261-3eed853a95b3)
