### PR TITLE
Add different types of wish cards

### DIFF
--- a/src/components/AccountPage/AccountBottomPart/Presents/Presents.tsx
+++ b/src/components/AccountPage/AccountBottomPart/Presents/Presents.tsx
@@ -19,13 +19,13 @@ export function Presents() {
             </div>
 
             <div className={globalStyles.wishWrapper}>
-                <Wish />
-                <Wish />
-                <Wish />
-                <Wish />
-                <Wish />
-                <Wish />
-                <Wish />
+                <Wish type="present" />
+                <Wish type="present" />
+                <Wish type="present" />
+                <Wish type="present" />
+                <Wish type="present" />
+                <Wish type="present" />
+                <Wish type="present" />
             </div>
         </section>
     )

--- a/src/components/AccountPage/AccountBottomPart/Wishlist/Wishlist.tsx
+++ b/src/components/AccountPage/AccountBottomPart/Wishlist/Wishlist.tsx
@@ -15,13 +15,13 @@ export function Wishlist() {
             </div>
 
             <div className={globaStyles.wishWrapper}>
-                <Wish />
-                <Wish />
-                <Wish />
-                <Wish />
-                <Wish />
-                <Wish />
-                <Wish />
+                <Wish type='personal_wish' />
+                <Wish type='personal_wish' />
+                <Wish type='personal_wish' />
+                <Wish type='personal_wish' />
+                <Wish type='personal_wish' />
+                <Wish type='personal_wish' />
+                <Wish type='personal_wish' />
             </div>
         </section>
     )

--- a/src/components/MainPage/Container/PopularWishes/PopularWishes.tsx
+++ b/src/components/MainPage/Container/PopularWishes/PopularWishes.tsx
@@ -9,7 +9,7 @@ export function PopularWishes() {
             <h2 className={styles.title}>Популярные желания</h2>
 
             <section className={globalStyles.wishWrapper}>
-                <Wish />
+                <Wish type='basic' />
             </section>
         </section>
     )

--- a/src/components/Wish/Wish.module.scss
+++ b/src/components/Wish/Wish.module.scss
@@ -1,7 +1,6 @@
 .wishCard {
     width: 100%;
     border-radius: 12px;
-    height: 493px;
     overflow: hidden;
     box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
     transition: var(--primary-transition);
@@ -34,7 +33,6 @@
     padding: 16px;
     display: flex;
     flex-direction: column;
-    height: 259px;
     gap: 21px;
 }
 
@@ -67,10 +65,7 @@
     display: flex;
     align-items: center;
 
-    &::before {
-        content: '\f3c5';
-        font-family: 'Font Awesome 5 Free';
-        font-weight: 900;
+    i {
         margin-right: 4px;
         font-size: 0.8rem;
     }

--- a/src/components/Wish/Wish.tsx
+++ b/src/components/Wish/Wish.tsx
@@ -1,40 +1,35 @@
-import styles from './Wish.module.scss'
+import type { JSX } from 'react';
+import { BasicWish } from './WishCardsTypes/BasicWish/BasicWish';
+import { PresentWish } from './WishCardsTypes/PresentWish/PresentWish';
+import { PersonalWish } from './WishCardsTypes/PersonalWish/PersonalWish';
 
-export function Wish() {
+export function Wish({ type }: { type: string }) {
+    let wishCard: JSX.Element = <BasicWish />;
+
+    switch (type) {
+        case 'present':
+            wishCard = <PresentWish />
+            break;
+
+        case 'personal_wish':
+            wishCard = <PersonalWish />
+            break;
+
+        case 'basic':
+            wishCard = <BasicWish />
+            break;
+
+        default:
+            wishCard = <BasicWish />
+            break;
+    }
+
+
+    console.log(wishCard);
+
     return (
-        <div className={styles.wishCard}>
-            <div className={styles.wishImage}>
-                <img src="/placeholder-wish.jpg" alt="Wish image" />
-            </div>
-
-            <div className={styles.wishContent}>
-                <div className={styles.userInfo}>
-                    <img src="/placeholder-avatar.jpg" alt="User avatar" />
-
-                    <div>
-                        <h3 className={styles.userName}>Костя</h3>
-                        <p className={styles.userLocation}>Минск</p>
-                    </div>
-                </div>
-
-                <div>
-                    <h3 className={styles.wishTitle}>Name of wish</h3>
-                    <p className={styles.wishDescription}>Description of the wish item that might be longer than one line and should be properly truncated</p>
-
-                    <div className={styles.wishMeta}>
-                        <span className={styles.marketplace}>
-                            <i className="fas fa-shopping-bag"></i> Wildberries
-                        </span>
-                        
-                        <span className={styles.price}>199.99 BYN</span>
-                    </div>
-                </div>
-
-                <button className={styles.detailsButton} type="button">
-                    Узнать больше
-                    <i className="fas fa-chevron-right"></i>
-                </button>
-            </div>
-        </div>
+        <>
+            {wishCard || <BasicWish />}
+        </>
     )
 }

--- a/src/components/Wish/WishCardsTypes/BasicWish/BasicWish.tsx
+++ b/src/components/Wish/WishCardsTypes/BasicWish/BasicWish.tsx
@@ -1,0 +1,43 @@
+import styles from '../../Wish.module.scss';
+
+export function BasicWish() {
+    return (
+        <div className={styles.wishCard}>
+            <div className={styles.wishImage} id='wishImage'>
+                <img src="null" alt="Wish image" />
+            </div>
+
+            <div className={styles.wishContent}>
+                <div className={styles.userInfo}>
+                    <img src="null" alt="User avatar" />
+
+                    <div>
+                        <h3 className={styles.userName}>Костя</h3>
+                        <p className={styles.userLocation}>
+                            <i className="fa-solid fa-location-dot"></i>
+                            Минск
+                        </p>
+                    </div>
+                </div>
+
+                <div>
+                    <h3 className={styles.wishTitle}>Name of wish</h3>
+                    <p className={styles.wishDescription}>Description of the wish item that might be longer than one line and should be properly truncated</p>
+
+                    <div className={styles.wishMeta}>
+                        <span className={styles.marketplace}>
+                            <i className="fas fa-shopping-bag"></i> Wildberries
+                        </span>
+
+                        <span className={styles.price}>199.99 BYN</span>
+                    </div>
+                </div>
+
+                <button className={styles.detailsButton} type="button">
+                    Узнать больше
+                    <i className="fas fa-chevron-right"></i>
+                </button>
+            </div>
+        </div>
+    )
+}

--- a/src/components/Wish/WishCardsTypes/PersonalWish/PersonalWish.module.scss
+++ b/src/components/Wish/WishCardsTypes/PersonalWish/PersonalWish.module.scss
@@ -1,0 +1,30 @@
+.actions {
+    display: flex;
+    width: 100%;
+    justify-content: space-between;
+
+    button {
+        color: var(--white);
+        background-color: var(--primary-color);
+        padding: 9px 12px;
+        border-radius: 10px;
+        font-weight: 600;
+        display: flex;
+        border: 2px solid var(--white);
+        align-items: center;
+        justify-content: center;
+        transition: var(--primary-transition);
+
+        &:hover {
+            background-color: var(--white);
+            color: var(--primary-color);
+            border: 2px solid var(--primary-color);
+        }
+
+        i {
+            font-size: 0.8rem;
+            transform: translateY(12%);
+            margin-right: 8px;
+        }
+    }
+}

--- a/src/components/Wish/WishCardsTypes/PersonalWish/PersonalWish.tsx
+++ b/src/components/Wish/WishCardsTypes/PersonalWish/PersonalWish.tsx
@@ -1,0 +1,51 @@
+import globalStyles from '../../Wish.module.scss';
+import additionalStyles from './PersonalWish.module.scss'
+
+export function PersonalWish() {
+    return (
+        <div className={globalStyles.wishCard}>
+            <div className={globalStyles.wishImage} id='wishImage'>
+                <img src="null" alt="Wish image" />
+            </div>
+
+            <div className={globalStyles.wishContent}>
+                <div className={globalStyles.userInfo}>
+                    <img src="null" alt="User avatar" />
+
+                    <div>
+                        <h3 className={globalStyles.userName}>Костя</h3>
+                        <p className={globalStyles.userLocation}>
+                            <i className="fa-solid fa-location-dot"></i>
+                            Минск
+                        </p>
+                    </div>
+                </div>
+
+                <div>
+                    <h3 className={globalStyles.wishTitle}>Name of wish</h3>
+                    <p className={globalStyles.wishDescription}>Description of the wish item that might be longer than one line and should be properly truncated</p>
+
+                    <div className={globalStyles.wishMeta}>
+                        <span className={globalStyles.marketplace}>
+                            <i className="fas fa-shopping-bag"></i> Wildberries
+                        </span>
+
+                        <span className={globalStyles.price}>199.99 BYN</span>
+                    </div>
+                </div>
+
+                <div className={additionalStyles.actions}>
+                    <button>
+                        <i className="fa-solid fa-pencil"></i>
+                        Редактировать
+                    </button>
+
+                    <button>
+                        <i className="fa-solid fa-check"></i>
+                        Получено
+                    </button>
+                </div>
+            </div>
+        </div>
+    )
+}

--- a/src/components/Wish/WishCardsTypes/PresentWish/PresentWish.tsx
+++ b/src/components/Wish/WishCardsTypes/PresentWish/PresentWish.tsx
@@ -1,0 +1,31 @@
+import styles from '../../Wish.module.scss';
+
+export function PresentWish() {
+    return (
+        <div className={`${styles.wishCard} ${styles.wishContent}`}>
+            <div className={styles.userInfo}>
+                <img src="null" alt="User avatar" />
+
+                <div>
+                    <h3 className={styles.userName}>Костя</h3>
+                    <p className={styles.userLocation}>
+                        <i className="fa-solid fa-location-dot"></i>
+                        Минск
+                    </p>
+                </div>
+            </div>
+
+            <div>
+                <h3 className={styles.wishTitle}>Name of wish</h3>
+
+                <div className={styles.wishMeta}>
+                    <span className={styles.marketplace}>
+                        <i className="fas fa-shopping-bag"></i> Wildberries
+                    </span>
+
+                    <span className={styles.price}>199.99 BYN</span>
+                </div>
+            </div>
+        </div>
+    )
+}

--- a/src/components/WishlistsPage/Wishes/Wishes.tsx
+++ b/src/components/WishlistsPage/Wishes/Wishes.tsx
@@ -4,8 +4,8 @@ import styles from './Wishes.module.css';
 import globalStyles from '../../global.module.css';
 
 export function Wishes({ isFiltersOpen }: { isFiltersOpen: boolean }) {
-
     const wishes = document.querySelector(`.${styles.wishes}`);
+
     if (isFiltersOpen && wishes) {
         wishes.style.padding = '30px 30px 30px 414px'
     } else if (!isFiltersOpen && wishes) {
@@ -14,12 +14,12 @@ export function Wishes({ isFiltersOpen }: { isFiltersOpen: boolean }) {
 
     return (
         <section className={`${globalStyles.wishWrapper} ${styles.wishes}`}>
-            <Wish />
-            <Wish />
-            <Wish />
-            <Wish />
-            <Wish />
-            <Wish />
+            <Wish type='basic' />
+            <Wish type='basic' />
+            <Wish type='basic' />
+            <Wish type='basic' />
+            <Wish type='basic' />
+            <Wish type='basic' />
         </section>
     )
 }


### PR DESCRIPTION
### What has been done

✅ **Added wish card types**:

- Regular wish card
- My wish card (user's wish)
- Wish card that I (the user) ordered

✅ **Component approach**:

- Moved all card types to separate components
- Created variations via props (`type="basic"`)

---

### How to check?

1. Open the page with cards: main, wishlists and account in the section my wishlist and ordered gifts.
2. Make sure that all types are visible.



Basic
![Screenshot 2025-06-12 104043](https://github.com/user-attachments/assets/8b2ca98b-5529-470c-bf51-ba68524db1d2)

My wish
![Screenshot 2025-06-12 104101](https://github.com/user-attachments/assets/b6674753-6986-4476-b6e7-779ce55deb39)

Ordered wishes
![Screenshot 2025-06-12 104110](https://github.com/user-attachments/assets/be30dd6e-98ff-4faf-88e9-ed92a9bee8e7)
